### PR TITLE
Add DUCBEdgeSampler for use in TrackAnnotator widget

### DIFF
--- a/src/tracktour/_napari/track_annotator/samplers.py
+++ b/src/tracktour/_napari/track_annotator/samplers.py
@@ -155,9 +155,13 @@ class DUCBEdgeSampler(EdgeSampler):
 
         # Navigation state
         self._visited: set = set()
-        # History entries: (df_index, arm_name_or_None)
-        self._history: list[tuple] = []
+        # History entries: [df_index, arm, reward] — mutable lists so reward can be updated.
+        # reward starts as None until provide_reward is called for that position.
+        self._history: list[list] = []
         self._hist_pos: int = -1
+        # Set when a reward is changed retroactively (at a non-frontier position).
+        # Triggers a full bandit-state recompute before the next frontier pick.
+        self._history_dirty: bool = False
 
         # Initialise by picking the first edge
         self._pick_next_and_append()
@@ -220,11 +224,33 @@ class DUCBEdgeSampler(EdgeSampler):
             self.discounted_arm_played[arm] *= self._gamma
             self.discounted_arm_rewards[arm] *= self._gamma
 
+    def _recompute_bandit_state(self) -> None:
+        """Recompute discounted_arm_played and discounted_arm_rewards from history.
+
+        Called when a retroactive reward change has dirtied the running totals.
+        O(H) where H is the number of history entries.
+
+        Each history entry at position i has been discounted by gamma once per
+        subsequent round, so its contribution is gamma^(H - 1 - i).
+        """
+        H = len(self._history)
+        for arm in self.discounted_arm_played:
+            self.discounted_arm_played[arm] = 0.0
+            self.discounted_arm_rewards[arm] = 0.0
+        for i, (_, arm, reward) in enumerate(self._history):
+            discount = self._gamma ** (H - 1 - i)
+            self.discounted_arm_played[arm] += discount
+            if reward is not None:
+                self.discounted_arm_rewards[arm] += reward * discount
+
     def _pick_next_and_append(self) -> bool:
         """Run one UCB round, append the chosen edge to history.
 
         Returns True if an edge was appended, False if all edges are exhausted.
         """
+        if self._history_dirty:
+            self._recompute_bandit_state()
+            self._history_dirty = False
         self._apply_discount()
         arm = self._select_arm()
         if arm is None:
@@ -235,7 +261,7 @@ class DUCBEdgeSampler(EdgeSampler):
         self.discounted_arm_played[arm] += 1.0
         self._arm_play_count[arm] += 1
         self._visited.add(df_idx)
-        self._history.append((df_idx, arm))
+        self._history.append([df_idx, arm, None])
         return True
 
     # ------------------------------------------------------------------
@@ -243,7 +269,7 @@ class DUCBEdgeSampler(EdgeSampler):
     # ------------------------------------------------------------------
 
     def current(self) -> tuple[int, int]:
-        df_idx, _ = self._history[self._hist_pos]
+        df_idx, _, _ = self._history[self._hist_pos]
         return self._edge_lookup[df_idx]
 
     def next(self) -> Optional[tuple[int, int]]:
@@ -279,7 +305,11 @@ class DUCBEdgeSampler(EdgeSampler):
         return self._hist_pos
 
     def provide_reward(self, reward: float) -> None:
-        """Update the reward sum for the arm that produced the current edge.
+        """Record the reward for the current edge and update bandit state.
+
+        At the frontier this is an O(1) update. At a previously visited
+        position, if the reward has changed, the dirty flag is set so the
+        full bandit state is recomputed (O(H)) before the next frontier pick.
 
         Parameters
         ----------
@@ -287,6 +317,15 @@ class DUCBEdgeSampler(EdgeSampler):
             Reward signal for the current edge. Typically 1.0 if the edge
             is an error and 0.0 if it is correct.
         """
-        _, arm = self._history[self._hist_pos]
-        if arm is not None:
-            self.discounted_arm_rewards[arm] += reward
+        entry = self._history[self._hist_pos]
+        _, arm, old_reward = entry
+        if old_reward == reward:
+            return
+        entry[2] = reward
+        at_frontier = self._hist_pos == len(self._history) - 1
+        if at_frontier:
+            # O(1) delta: subtract old contribution (0 if never set) and add new
+            previous = old_reward if old_reward is not None else 0.0
+            self.discounted_arm_rewards[arm] += reward - previous
+        else:
+            self._history_dirty = True

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -280,10 +280,71 @@ def test_ducb_n_and_s_discounted_on_next_call(simple_edges_df):
 def test_ducb_two_arms_each_played_before_ucb(two_arm_edges_df):
     # Both arms have N=0 at start, so each is played once before UCB kicks in
     sampler = DUCBEdgeSampler(two_arm_edges_df, {"score": True, "rank": True})
-    _, arm0 = sampler._history[0]
+    _, arm0, _ = sampler._history[0]
     sampler.next()
-    _, arm1 = sampler._history[1]
+    _, arm1, _ = sampler._history[1]
     assert {arm0, arm1} == {"score", "rank"}
+
+
+def test_ducb_provide_reward_stores_in_history(simple_edges_df):
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    assert sampler._history[0][2] == 1.0
+
+
+def test_ducb_provide_reward_same_value_is_noop(simple_edges_df):
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    rewards_before = sampler.discounted_arm_rewards["score"]
+    sampler.provide_reward(1.0)
+    assert sampler.discounted_arm_rewards["score"] == rewards_before
+
+
+def test_ducb_retroactive_reward_sets_dirty_flag(simple_edges_df):
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    sampler.next()
+    sampler.provide_reward(0.0)
+    sampler.previous()
+    # back at position 0, which is not at the frontier
+    sampler.provide_reward(0.0)  # change from 1.0 to 0.0
+    assert sampler._history_dirty
+
+
+def test_ducb_retroactive_reward_same_value_does_not_set_dirty(simple_edges_df):
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    sampler.next()
+    sampler.previous()
+    sampler.provide_reward(1.0)  # same value — no change
+    assert not sampler._history_dirty
+
+
+def test_ducb_recompute_clears_dirty_flag(simple_edges_df):
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    sampler.next()
+    sampler.previous()
+    sampler.provide_reward(0.0)
+    assert sampler._history_dirty
+    sampler.next()  # advances to frontier, triggering recompute
+    sampler.next()  # now at new frontier: recompute should have run
+    assert not sampler._history_dirty
+
+
+def test_ducb_recompute_bandit_state_matches_incremental(simple_edges_df):
+    # Build a sampler the normal incremental way
+    sampler = DUCBEdgeSampler(simple_edges_df, {"score": True})
+    sampler.provide_reward(1.0)
+    sampler.next()
+    sampler.provide_reward(0.0)
+    incremental_played = dict(sampler.discounted_arm_played)
+    incremental_rewards = dict(sampler.discounted_arm_rewards)
+
+    # Force a full recompute and check it matches
+    sampler._recompute_bandit_state()
+    assert sampler.discounted_arm_played == pytest.approx(incremental_played)
+    assert sampler.discounted_arm_rewards == pytest.approx(incremental_rewards)
 
 
 def test_ducb_empty_bandit_arms_raises():


### PR DESCRIPTION
- Add DUCBEdgeSampler that takes in an edges_df and a set of bandit arms that are features in the edges_df and allows for DUCB sampling of edges
- DUCBEdgeSampler tracks all history so that we can go back through previous edges (like RandomEdgeSampler)
- If the user changes a previously seen edge, this could theoretically change the sampling order of all future edges. However, since we may have already annotated some other edges beyond this point, we simply mark the history as "dirty" and when we get to the first unseen edge again, we recompute the bandit state from there. This means we'll not be following "true" DUCB sampling but it also means the user will have a coherent sampling order...