### PR TITLE
Update solver to export GEFF and compute features

### DIFF
--- a/src/tracktour/_features.py
+++ b/src/tracktour/_features.py
@@ -9,8 +9,12 @@ must therefore be called immediately after solving, before the model is
 discarded.
 """
 
+import re
+
 import numpy as np
 from scipy.special import softmax as scipy_softmax
+
+_FLOW_VAR_RE = re.compile(r"flow[\[(](\d+)")
 
 
 def assign_migration_features(all_edges):
@@ -69,7 +73,7 @@ def assign_sensitivity_features(all_edges, model):
     sens_diffs = [None] * len(all_edges)
 
     for var in model.getVars():
-        edg_idx, _src, _dst = eval(var.varName.lstrip("flow"))
+        edg_idx = int(_FLOW_VAR_RE.match(var.varName).group(1))
         edg_row = all_edges.loc[edg_idx]
         if var.X == 0:
             sens_diff = abs(edg_row["cost"] - var.SAObjLow)

--- a/src/tracktour/_napari/_solver.py
+++ b/src/tracktour/_napari/_solver.py
@@ -1,17 +1,13 @@
-import typing
 import warnings
 
-import networkx as nx
 import numpy as np
-import pandas as pd
 from dask.array import Array
-from magicgui.widgets import ComboBox, Container, PushButton, create_widget
+from magicgui.widgets import Container, PushButton, create_widget
 
+from tracktour._geff_io import write_candidate_geff, write_solution_geff
 from tracktour._io_util import extract_im_centers
 from tracktour._napari._graph_conversion_util import get_coloured_solution_layers
 from tracktour._tracker import Cost, Tracker
-
-# from napari.qt.threading import create_worker
 
 
 class TrackingSolver(Container):
@@ -26,6 +22,7 @@ class TrackingSolver(Container):
             labels=labels,
         )
         self._viewer = viewer
+        self._tracked = None
 
         self._seg_layer_combo = create_widget(
             annotation="napari.layers.Labels", label="Segmentation Layer"
@@ -41,6 +38,16 @@ class TrackingSolver(Container):
         self._solve_button = PushButton(text="Solve")
         self._solve_button.clicked.connect(self._solve_graph)
 
+        self._export_solution_button = PushButton(text="Export Solution to GEFF")
+        self._export_solution_button.clicked.connect(self._export_solution_geff)
+        self._export_solution_button.enabled = False
+
+        self._export_candidate_button = PushButton(
+            text="Export Candidate Graph to GEFF"
+        )
+        self._export_candidate_button.clicked.connect(self._export_candidate_geff)
+        self._export_candidate_button.enabled = False
+
         self.extend(
             [
                 self._seg_layer_combo,
@@ -48,6 +55,8 @@ class TrackingSolver(Container):
                 self._n_children_spin,
                 self._cost_combo,
                 self._solve_button,
+                self._export_solution_button,
+                self._export_candidate_button,
             ]
         )
 
@@ -57,25 +66,7 @@ class TrackingSolver(Container):
         n_neighbours = self._n_neighbours_spin.value
         n_children = self._n_children_spin.value
         cost_choice = self._cost_combo.value
-        # centers, labels = [], []
 
-        # def yield_extend(yielded):
-        #     cent, lab = yielded
-        #     centers.extend(cent)
-        #     labels.extend(lab)
-
-        # center_worker = create_worker(
-        #     get_centers,
-        #     segmentation=segmentation,
-        #     _progress={
-        #         'total':len(segmentation),
-        #         'desc':'Extracting Centers'
-        #         },
-        #     _connect={
-        #         'yielded': yield_extend
-        #         }
-        #     )
-        # coords_df, min_t, max_t, corners = get_im_info(centers, labels, segmentation)
         if isinstance(segmentation, Array):
             warnings.warn(
                 "Your segmentation is a dask array which is not currently supported. Will attempt conversion to numpy array."
@@ -86,17 +77,46 @@ class TrackingSolver(Container):
         tracker = Tracker(
             im_shape=segmentation.shape[1:], seg=segmentation, scale=seg_layer.scale[1:]
         )
+        tracker.DEBUG_MODE = True
         tracker.DIVISION_EDGE_CAPACITY = n_children - 1
         tracked = tracker.solve(
             coords_df, value_key="label", k_neighbours=n_neighbours, costs=cost_choice
         )
+        tracked.assign_features()
 
-        # make tracks layer and coloured seg/points layer
         coloured_points, coloured_labels, tracks = get_coloured_solution_layers(
             tracked,
             tracker.scale,
             segmentation,
         )
+        tracks.metadata["tracked"] = tracked
+
         self._viewer.add_layer(coloured_points)
         self._viewer.add_layer(coloured_labels)
         self._viewer.add_layer(tracks)
+
+        self._tracked = tracked
+        self._export_solution_button.enabled = True
+        self._export_candidate_button.enabled = True
+
+    def _export_solution_geff(self):
+        if self._tracked is None:
+            return
+        from qtpy.QtWidgets import QFileDialog
+
+        path, _ = QFileDialog.getSaveFileName(
+            None, "Export solution to GEFF", "", "GEFF files (*.geff)"
+        )
+        if path:
+            write_solution_geff(self._tracked, path)
+
+    def _export_candidate_geff(self):
+        if self._tracked is None:
+            return
+        from qtpy.QtWidgets import QFileDialog
+
+        path, _ = QFileDialog.getSaveFileName(
+            None, "Export candidate graph to GEFF", "", "GEFF files (*.geff)"
+        )
+        if path:
+            write_candidate_geff(self._tracked, path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared pytest fixtures for tracktool tests."""
+"""Shared pytest fixtures for tracktour tests."""
 
 import types
 
@@ -229,17 +229,23 @@ def mock_gurobi_model():
     """Factory fixture returning a mock Gurobi model for a given all_edges DataFrame.
 
     Each variable has:
-      - varName: "flow(idx, src, dst)" matching the row index and u/v columns
+      - varName: "flow[idx,src,dst]" matching the row index and u/v columns.
+        Virtual vertex IDs are mapped to their Gurobi string labels
+        (-1→s, -2→a, -3→d, -4→t) to match real Gurobi output.
       - X: 1.0 if flow > 0 else 0.0
       - SAObjLow: cost - 0.1
       - SAObjUp: cost + 0.1
     """
+    _virtual_labels = {-1: "s", -2: "a", -3: "d", -4: "t"}
+
+    def _node_label(n):
+        return _virtual_labels.get(n, n)
 
     def _make_model(all_edges):
         vars_ = []
         for row in all_edges.itertuples():
             var = types.SimpleNamespace(
-                varName=f"flow({row.Index}, {row.u}, {row.v})",
+                varName=f"flow[{row.Index},{_node_label(row.u)},{_node_label(row.v)}]",
                 X=float(row.flow) if hasattr(row, "flow") else 0.0,
                 SAObjLow=row.cost - 0.1,
                 SAObjUp=row.cost + 0.1,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -127,6 +127,24 @@ def test_sensitivity_features_returns_expected_column_names(
     assert cols == ["sa_obj_low", "sa_obj_up", "sensitivity_diff"]
 
 
+def test_sensitivity_features_parses_virtual_vertex_string_labels(
+    synthetic_tracked, mock_gurobi_model
+):
+    # Virtual edges have varNames like flow[12,s,3] — string labels for virtual nodes.
+    # Parsing must not raise a NameError.
+    model = mock_gurobi_model(synthetic_tracked.all_edges)
+    virtual_var_names = [
+        v.varName
+        for v in model.getVars()
+        if any(
+            label in v.varName
+            for label in (",s,", ",a,", ",d,", ",t,", ",s]", ",a]", ",d]", ",t]")
+        )
+    ]
+    assert len(virtual_var_names) > 0, "fixture has no virtual-vertex variable names"
+    assign_sensitivity_features(synthetic_tracked.all_edges, model)  # must not raise
+
+
 def test_sensitivity_features_non_selected_edge_uses_sa_obj_low(
     synthetic_tracked, mock_gurobi_model
 ):


### PR DESCRIPTION
Updates the solver to:

- assign features after computing solution (to be used in TrackAnnotator)
- allow exporting both the solution and candidate GEFF after solving
- save the tracked object to layer metadata

This way the user can either select a Tracks layer with a tracked meta attribute to perform annotation, or load an existing GEFF.

Also fixes a bug with computing features for edges with virtual vertices adjacent.