### PR TITLE
Change image projection mode in thick slicing to None

### DIFF
--- a/src/tracktour/_napari/track_annotator/widget.py
+++ b/src/tracktour/_napari/track_annotator/widget.py
@@ -516,7 +516,7 @@ class TrackAnnotator(QWidget):
         for layer in self._viewer.layers:
             if layer.visible:
                 if type(layer).__name__ == "Image":
-                    layer.projection_mode = "MEAN"
+                    layer.projection_mode = "NONE"
 
     def _display_next_edge(self):
         current_edge = self._edge_sampler.current()


### PR DESCRIPTION
Prior to this PR we set default projection mode for images to `mean` when enabling thick slicing to display our current edge.

This PR changes it to `none`, so that users don't unexpectedly get "ghosts" of other slices displayed on their canvas.